### PR TITLE
refactor: extract Slack API into randomtools.slack package

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,34 @@ Configuration:
 
 ## Slack Tools
 
+### slack-send (1.0)
+
+```
+Send a message or file to a Slack channel.
+
+Usage:
+    slack-send [options] CHANNEL [TEXT...]
+    slack-send [options] CHANNEL -f FILE [TEXT...]
+
+Options:
+    -f FILE, --file FILE           Send FILE as a Slack file upload.
+    -h, --help                     Show this message.
+    --version                      Show version information.
+
+Arguments:
+    CHANNEL   Channel name or ID (e.g. general, #general, C01234ABCDE).
+    TEXT      Message text. If omitted and no --file, reads from stdin.
+              When used with --file, sent as the accompanying comment.
+
+Examples:
+    slack-send general "Hello, world!"
+    slack-send '#dev' "Deploy complete"
+    echo "Pipeline passed" | slack-send general
+    slack-send general -f report.md
+    slack-send general -f report.md "Weekly report"
+    echo "See attached" | slack-send general -f report.md
+```
+
 ### slack-channels (1.1)
 
 ```

--- a/README.md.in
+++ b/README.md.in
@@ -81,6 +81,8 @@ maptocsv -k email -v link soda/domain_map.json soda/domain_map.csv
 
 ## Slack Tools
 
+[$ make-readme -h 3 slack-send]
+
 [$ make-readme -h 3 slack-channels]
 
 ## Markdown utilities

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -1,0 +1,154 @@
+# `randomtools.slack`
+
+Slack API client library for channel operations, messaging, and file uploads.
+
+All functions accept a Slack API token (`xoxp-...` user token) as their first argument. Token management is handled by `randomtools.config.slack.SlackConfigFile`, which reads `~/.slack/config.ini`.
+
+## Configuration
+
+```ini
+# ~/.slack/config.ini
+[Slack]
+token = xoxp-...
+```
+
+## Exceptions
+
+### `SlackAPIError(method, error)`
+
+Base exception for Slack API errors. Attributes:
+
+- `method` (str) -- the API method that failed (e.g. `"conversations.list"`).
+- `error` (str) -- error string returned by Slack.
+
+### `ChannelNotFoundError(channel_name)`
+
+Subclass of `SlackAPIError`. Raised when `find_channel()` cannot resolve a channel name.
+
+- `channel_name` (str) -- the name that was looked up.
+
+## `channels` module
+
+### `find_channel(token, channel_name)`
+
+Resolve a channel name to its ID.
+
+- Strips leading `#` from the name.
+- If *channel_name* looks like a channel ID (starts with `C`, rest alphanumeric), returns it directly without an API call.
+
+**Returns:** `(channel_id, channel_name)` -- *channel_name* is `None` when a raw ID was passed in.
+
+**Raises:** `ChannelNotFoundError`, `SlackAPIError`
+
+```python
+from randomtools.slack import find_channel
+
+channel_id, name = find_channel(token, "#general")
+channel_id, _    = find_channel(token, "C01234ABCDE")
+```
+
+### `fetch_all_channels(token, exclude_archived=True)`
+
+Fetch all accessible channels (public and private) with pagination.
+
+**Returns:** `list[dict]` -- channel objects as returned by the Slack API.
+
+**Raises:** `SlackAPIError`
+
+```python
+from randomtools.slack import fetch_all_channels
+
+channels = fetch_all_channels(token)
+for ch in channels:
+    print(ch['name'], ch['id'])
+```
+
+### `fetch_channel_members(token, channel_id)`
+
+Fetch all member user IDs from a channel.
+
+**Returns:** `list[str]` -- Slack user IDs.
+
+**Raises:** `SlackAPIError`
+
+### `fetch_last_message_ts(token, channel_id)`
+
+Get the timestamp of the most recent message in a channel.
+
+**Returns:** `float | None` -- Unix timestamp, or `None` if the channel is empty or the call fails.
+
+## `messages` module
+
+### `post_message(token, channel_id, text)`
+
+Send a text message to a channel via `chat.postMessage`. Supports Slack mrkdwn formatting.
+
+**Returns:** `dict` -- Slack API response.
+
+**Raises:** `SlackAPIError`
+
+```python
+from randomtools.slack import find_channel, post_message
+
+channel_id, _ = find_channel(token, "general")
+post_message(token, channel_id, "Hello, world!")
+```
+
+## `files` module
+
+### `upload_file(token, channel_id, filename, content, initial_comment=None, title=None)`
+
+Upload a file to a channel using the 3-step external upload flow.
+
+| Argument | Type | Description |
+|---|---|---|
+| `token` | `str` | Slack API token |
+| `channel_id` | `str` | Target channel ID |
+| `filename` | `str` | Display name (e.g. `"report.md"`) |
+| `content` | `bytes` | File content |
+| `initial_comment` | `str \| None` | Message posted alongside the file |
+| `title` | `str \| None` | File title in Slack (defaults to *filename*) |
+
+**Returns:** `dict` -- Slack API response.
+
+**Raises:** `SlackAPIError`
+
+```python
+from pathlib import Path
+from randomtools.slack import find_channel, upload_file
+
+channel_id, _ = find_channel(token, "general")
+p = Path("report.md")
+upload_file(token, channel_id, p.name, p.read_bytes(),
+            initial_comment="Weekly report", title=p.stem)
+```
+
+## CLI: `slack-send`
+
+```
+Usage:
+    slack-send [options] CHANNEL [TEXT...]
+    slack-send [options] CHANNEL -f FILE [TEXT...]
+
+Options:
+    -f FILE, --file FILE    Send FILE as a Slack file upload.
+    -h, --help              Show this message.
+    --version               Show version information.
+```
+
+When `-f` is combined with text, the text is sent as the file's accompanying comment. Without `-f`, text is sent as a regular message. Text can come from arguments or stdin.
+
+```bash
+# Send a message
+slack-send general "Hello, world!"
+
+# Pipe from stdin
+echo "Deploy complete" | slack-send general
+
+# Upload a file
+slack-send general -f report.md
+
+# Upload a file with a comment
+slack-send general -f report.md "Weekly report"
+echo "See attached" | slack-send general -f report.md
+```

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
     ],
-    packages=('randomtools', 'randomtools.config'),
+    packages=('randomtools', 'randomtools.config', 'randomtools.slack'),
     package_dir={'': 'src'},
     install_requires=['docopt', 'thefuzz', 'requests', 'pydantic', 'google-auth', 'google-auth-oauthlib', 'google-api-python-client', 'more-itertools', 'dateparser', 'pyyaml', 'whosename-client @ git+ssh://git@github.com/makimo/whose-name-client@main#egg=whosename-main'],
     python_requires='>=3',
@@ -41,6 +41,7 @@ setup(
             'calamari-absences = randomtools.calamari_absences:main',
             'jira-harvest = randomtools.jira_harvest:main',
             'jira-harvest-check = randomtools.jira_harvest_check:main',
+            'slack-send = randomtools.slack.send:main',
         ],
     }
 )

--- a/src/randomtools/jira_calendar.py
+++ b/src/randomtools/jira_calendar.py
@@ -74,6 +74,7 @@ from googleapiclient.errors import HttpError
 
 from .config.jira import JiraConfigFile
 from .config.slack import SlackConfigFile
+from .slack import find_channel, fetch_channel_members, post_message, SlackAPIError
 
 VERSION = '1.1'
 
@@ -647,73 +648,6 @@ def update_issue_description(jira_config, issue_key, description_text):
 
 # --- Slack ---
 
-def find_channel_by_name(token, channel_name):
-    """Find a Slack channel by name and return its ID."""
-    channel_name = channel_name.lstrip('#')
-    cursor = None
-    url = 'https://slack.com/api/conversations.list'
-
-    while True:
-        params = {
-            'types': 'public_channel,private_channel',
-            'exclude_archived': 'true',
-            'limit': 1000,
-        }
-        if cursor:
-            params['cursor'] = cursor
-
-        resp = requests.post(url, data=params, headers={
-            'Authorization': f'Bearer {token}',
-        })
-        resp.raise_for_status()
-        data = resp.json()
-
-        if not data.get('ok'):
-            raise Exception(f"Slack API error: {data.get('error', 'unknown')}")
-
-        for ch in data.get('channels', []):
-            if ch['name'] == channel_name:
-                return ch['id'], ch['name']
-
-        cursor = data.get('response_metadata', {}).get('next_cursor')
-        if not cursor:
-            break
-
-    raise Exception(f"Slack channel '{channel_name}' not found")
-
-
-def fetch_channel_members(token, channel_id):
-    """Fetch all member user IDs from a Slack channel."""
-    members = []
-    cursor = None
-    url = 'https://slack.com/api/conversations.members'
-
-    while True:
-        params = {
-            'channel': channel_id,
-            'limit': 1000,
-        }
-        if cursor:
-            params['cursor'] = cursor
-
-        resp = requests.post(url, data=params, headers={
-            'Authorization': f'Bearer {token}',
-        })
-        resp.raise_for_status()
-        data = resp.json()
-
-        if not data.get('ok'):
-            raise Exception(f"Slack API error fetching members: {data.get('error', 'unknown')}")
-
-        members.extend(data.get('members', []))
-
-        cursor = data.get('response_metadata', {}).get('next_cursor')
-        if not cursor:
-            break
-
-    return members
-
-
 def resolve_member_emails(slack_ids):
     """Resolve Slack user IDs to email addresses using whosename."""
     from whosename import name_of
@@ -747,20 +681,11 @@ def send_slack_notification(token, channel_id, title, description,
 
     text = '\n'.join(lines)
 
-    resp = requests.post('https://slack.com/api/chat.postMessage', json={
-        'channel': channel_id,
-        'text': text,
-    }, headers={
-        'Authorization': f'Bearer {token}',
-        'Content-Type': 'application/json',
-    })
-    resp.raise_for_status()
-    data = resp.json()
-
-    if not data.get('ok'):
-        print(f"Warning: Could not send Slack message: {data.get('error', 'unknown')}")
-    else:
+    try:
+        post_message(token, channel_id, text)
         print(f"Sent meeting notification to Slack channel")
+    except SlackAPIError as e:
+        print(f"Warning: Could not send Slack message: {e.error}")
 
 
 # --- Main ---
@@ -828,7 +753,7 @@ def main():
             slack_config = SlackConfigFile()
 
             print(f"Looking up Slack channel: {slack_channel}...")
-            channel_id, resolved_name = find_channel_by_name(slack_config.token, slack_channel)
+            channel_id, resolved_name = find_channel(slack_config.token, slack_channel)
             print(f"Found channel: #{resolved_name}")
 
             print(f"Fetching channel members...")
@@ -873,7 +798,7 @@ def main():
         channel_id = None
         if config.slack_message and config.slack_channel:
             slack_config = SlackConfigFile()
-            channel_id, _ = find_channel_by_name(slack_config.token, config.slack_channel)
+            channel_id, _ = find_channel(slack_config.token, config.slack_channel)
 
         # Initialize calendar service and target calendar
         calendar_name_or_id = calendar_override or google_config.selected_calendar

--- a/src/randomtools/jira_report_weekly.py
+++ b/src/randomtools/jira_report_weekly.py
@@ -20,10 +20,10 @@ import subprocess
 import sys
 from pathlib import Path
 
-import requests
 from docopt import docopt
 
 from .config.slack import SlackConfigFile
+from .slack import find_channel, upload_file, SlackAPIError
 
 VERSION = '1.0'
 
@@ -57,91 +57,6 @@ def open_editor(filepath):
     editor = os.environ.get('EDITOR', 'vi')
     result = subprocess.run([editor, str(filepath)])
     return result.returncode == 0
-
-
-def resolve_channel_id(token, channel):
-    """Resolve a channel name to its ID. Returns the input if already an ID."""
-    if channel.startswith('C') and channel[1:].isalnum():
-        return channel
-
-    headers = {'Authorization': f'Bearer {token}'}
-    cursor = None
-
-    while True:
-        params = {'limit': 200, 'types': 'public_channel,private_channel'}
-        if cursor:
-            params['cursor'] = cursor
-
-        resp = requests.get('https://slack.com/api/conversations.list',
-                            params=params, headers=headers)
-        resp.raise_for_status()
-        data = resp.json()
-
-        if not data.get('ok'):
-            print(f"Slack error (conversations.list): {data.get('error', 'unknown')}", file=sys.stderr)
-            return None
-
-        for ch in data.get('channels', []):
-            if ch['name'] == channel:
-                return ch['id']
-
-        cursor = data.get('response_metadata', {}).get('next_cursor')
-        if not cursor:
-            break
-
-    print(f"Slack channel '{channel}' not found.", file=sys.stderr)
-    return None
-
-
-def send_to_slack(token, channel, filepath):
-    """Upload a file to a Slack channel with an accompanying message."""
-    headers = {'Authorization': f'Bearer {token}'}
-
-    channel_id = resolve_channel_id(token, channel)
-    if not channel_id:
-        return False
-
-    content = filepath.read_bytes()
-
-    # Step 1: Get upload URL
-    resp = requests.get('https://slack.com/api/files.getUploadURLExternal', params={
-        'filename': filepath.name,
-        'length': len(content),
-    }, headers=headers)
-    resp.raise_for_status()
-    data = resp.json()
-
-    if not data.get('ok'):
-        print(f"Slack error (getUploadURL): {data.get('error', 'unknown')}", file=sys.stderr)
-        return False
-
-    upload_url = data['upload_url']
-    file_id = data['file_id']
-
-    # Step 2: Upload file content
-    resp = requests.post(upload_url, data=content, headers={
-        'Content-Type': 'application/octet-stream',
-    })
-    resp.raise_for_status()
-
-    # Step 3: Complete upload and share to channel
-    resp = requests.post('https://slack.com/api/files.completeUploadExternal', json={
-        'files': [{'id': file_id, 'title': filepath.stem}],
-        'channel_id': channel_id,
-        'initial_comment': 'Podsumowanie tygodnia',
-    }, headers={
-        **headers,
-        'Content-Type': 'application/json',
-    })
-    resp.raise_for_status()
-    data = resp.json()
-
-    if not data.get('ok'):
-        print(f"Slack error (completeUpload): {data.get('error', 'unknown')}", file=sys.stderr)
-        return False
-
-    print(f"Sent weekly report to #{channel}", file=sys.stderr)
-    return True
 
 
 def run_journal(sunday, filepath):
@@ -199,7 +114,17 @@ def main():
         print("No Slack channel configured. Set [Weekly Report] channel in ~/.slack/config.ini or use --channel.", file=sys.stderr)
         return 1
 
-    if not send_to_slack(slack_config.token, channel, filepath):
+    try:
+        channel_id, _ = find_channel(slack_config.token, channel)
+        upload_file(
+            slack_config.token, channel_id,
+            filepath.name, filepath.read_bytes(),
+            initial_comment='Podsumowanie tygodnia',
+            title=filepath.stem,
+        )
+        print(f"Sent weekly report to #{channel}", file=sys.stderr)
+    except SlackAPIError as e:
+        print(str(e), file=sys.stderr)
         return 1
 
     # Step 3b: Journal the entry

--- a/src/randomtools/slack/__init__.py
+++ b/src/randomtools/slack/__init__.py
@@ -1,0 +1,22 @@
+"""Slack API client library for channel operations, messaging, and file uploads.
+
+Provides a unified interface to common Slack Web API methods. All functions
+accept a Slack API token (xoxp-... user token) as their first argument.
+Configuration is handled separately via ``randomtools.config.slack.SlackConfigFile``.
+
+Modules:
+    channels -- Channel lookup, listing, membership, and history.
+    messages -- Sending text messages via chat.postMessage.
+    files    -- File uploads via the external upload flow.
+"""
+
+from .channels import (
+    SlackAPIError,
+    ChannelNotFoundError,
+    find_channel,
+    fetch_all_channels,
+    fetch_channel_members,
+    fetch_last_message_ts,
+)
+from .messages import post_message
+from .files import upload_file

--- a/src/randomtools/slack/channels.py
+++ b/src/randomtools/slack/channels.py
@@ -1,0 +1,193 @@
+"""Slack channel operations: lookup, listing, members."""
+
+from __future__ import annotations
+
+import requests
+
+
+class SlackAPIError(Exception):
+    """Raised when a Slack API call returns ok=false."""
+
+    def __init__(self, method: str, error: str):
+        self.method = method
+        self.error = error
+        super().__init__(f"Slack API error ({method}): {error}")
+
+
+class ChannelNotFoundError(SlackAPIError):
+    """Raised when a channel name cannot be resolved to an ID."""
+
+    def __init__(self, channel_name: str):
+        self.channel_name = channel_name
+        super().__init__('conversations.list', f"Channel '{channel_name}' not found")
+
+
+def find_channel(token: str, channel_name: str) -> tuple[str, str | None]:
+    """Find a Slack channel by name and return ``(channel_id, channel_name)``.
+
+    Strips leading ``#`` from *channel_name*. If the input already looks like
+    a channel ID (starts with ``C``, rest alphanumeric), it is returned
+    directly as ``(channel_id, None)`` without making an API call.
+
+    Args:
+        token (str): Slack API token.
+        channel_name (str): Channel name (e.g. ``"general"``, ``"#general"``)
+            or channel ID (e.g. ``"C01234ABCDE"``).
+
+    Returns:
+        tuple[str, str | None]: ``(channel_id, channel_name)``; *channel_name*
+        is ``None`` when a raw ID was passed in.
+
+    Raises:
+        ChannelNotFoundError: If no channel matches the given name.
+        SlackAPIError: On other Slack API errors.
+    """
+    channel_name = channel_name.lstrip('#')
+
+    if channel_name.startswith('C') and channel_name[1:].isalnum() and len(channel_name) > 1:
+        return channel_name, None
+
+    headers = {'Authorization': f'Bearer {token}'}
+    cursor = None
+
+    while True:
+        params = {
+            'types': 'public_channel,private_channel',
+            'exclude_archived': 'true',
+            'limit': 1000,
+        }
+        if cursor:
+            params['cursor'] = cursor
+
+        resp = requests.get('https://slack.com/api/conversations.list',
+                            params=params, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+
+        if not data.get('ok'):
+            raise SlackAPIError('conversations.list', data.get('error', 'unknown'))
+
+        for ch in data.get('channels', []):
+            if ch['name'] == channel_name:
+                return ch['id'], ch['name']
+
+        cursor = data.get('response_metadata', {}).get('next_cursor')
+        if not cursor:
+            break
+
+    raise ChannelNotFoundError(channel_name)
+
+
+def fetch_all_channels(token: str, exclude_archived: bool = True) -> list[dict]:
+    """Fetch all accessible channels (public and private).
+
+    Args:
+        token (str): Slack API token.
+        exclude_archived (bool): Skip archived channels. Defaults to ``True``.
+
+    Returns:
+        list[dict]: Channel objects as returned by the Slack API.
+
+    Raises:
+        SlackAPIError: On Slack API errors.
+    """
+    channels = []
+    headers = {'Authorization': f'Bearer {token}'}
+    cursor = None
+
+    while True:
+        params = {
+            'types': 'public_channel,private_channel',
+            'exclude_archived': 'true' if exclude_archived else 'false',
+            'limit': 1000,
+        }
+        if cursor:
+            params['cursor'] = cursor
+
+        resp = requests.get('https://slack.com/api/conversations.list',
+                            params=params, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+
+        if not data.get('ok'):
+            raise SlackAPIError('conversations.list', data.get('error', 'unknown'))
+
+        channels.extend(data.get('channels', []))
+
+        cursor = data.get('response_metadata', {}).get('next_cursor')
+        if not cursor:
+            break
+
+    return channels
+
+
+def fetch_channel_members(token: str, channel_id: str) -> list[str]:
+    """Fetch all member user IDs from a Slack channel.
+
+    Args:
+        token (str): Slack API token.
+        channel_id (str): Channel ID.
+
+    Returns:
+        list[str]: Slack user IDs of channel members.
+
+    Raises:
+        SlackAPIError: On Slack API errors.
+    """
+    members = []
+    headers = {'Authorization': f'Bearer {token}'}
+    cursor = None
+
+    while True:
+        params = {
+            'channel': channel_id,
+            'limit': 1000,
+        }
+        if cursor:
+            params['cursor'] = cursor
+
+        resp = requests.get('https://slack.com/api/conversations.members',
+                            params=params, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+
+        if not data.get('ok'):
+            raise SlackAPIError('conversations.members', data.get('error', 'unknown'))
+
+        members.extend(data.get('members', []))
+
+        cursor = data.get('response_metadata', {}).get('next_cursor')
+        if not cursor:
+            break
+
+    return members
+
+
+def fetch_last_message_ts(token: str, channel_id: str) -> float | None:
+    """Fetch the timestamp of the last message in a channel.
+
+    Args:
+        token (str): Slack API token.
+        channel_id (str): Channel ID.
+
+    Returns:
+        float | None: Unix timestamp of the last message, or ``None`` if the
+        channel has no messages or the API call fails.
+    """
+    resp = requests.get('https://slack.com/api/conversations.history', params={
+        'channel': channel_id,
+        'limit': 1,
+    }, headers={
+        'Authorization': f'Bearer {token}',
+    })
+    resp.raise_for_status()
+    data = resp.json()
+
+    if not data.get('ok'):
+        return None
+
+    messages = data.get('messages', [])
+    if not messages:
+        return None
+
+    return float(messages[0]['ts'])

--- a/src/randomtools/slack/files.py
+++ b/src/randomtools/slack/files.py
@@ -1,0 +1,72 @@
+"""Slack file upload via the 3-step external upload flow."""
+
+from __future__ import annotations
+
+import requests
+
+from .channels import SlackAPIError
+
+
+def upload_file(token: str, channel_id: str, filename: str, content: bytes,
+                initial_comment: str | None = None, title: str | None = None) -> dict:
+    """Upload a file to a Slack channel.
+
+    Uses the 3-step external upload flow:
+    ``getUploadURLExternal`` -> PUT content -> ``completeUploadExternal``.
+
+    Args:
+        token (str): Slack API token.
+        channel_id (str): Channel ID to share the file to.
+        filename (str): Display name for the file (e.g. ``"report.md"``).
+        content (bytes): File content.
+        initial_comment (str | None): Optional message posted alongside the file.
+        title (str | None): File title shown in Slack. Defaults to *filename*.
+
+    Returns:
+        dict: Slack API response data.
+
+    Raises:
+        SlackAPIError: If any step of the upload flow fails.
+    """
+    headers = {'Authorization': f'Bearer {token}'}
+
+    # Step 1: Get upload URL
+    resp = requests.get('https://slack.com/api/files.getUploadURLExternal', params={
+        'filename': filename,
+        'length': len(content),
+    }, headers=headers)
+    resp.raise_for_status()
+    data = resp.json()
+
+    if not data.get('ok'):
+        raise SlackAPIError('files.getUploadURLExternal', data.get('error', 'unknown'))
+
+    upload_url = data['upload_url']
+    file_id = data['file_id']
+
+    # Step 2: Upload file content
+    resp = requests.post(upload_url, data=content, headers={
+        'Content-Type': 'application/octet-stream',
+    })
+    resp.raise_for_status()
+
+    # Step 3: Complete upload and share to channel
+    complete_payload = {
+        'files': [{'id': file_id, 'title': title or filename}],
+        'channel_id': channel_id,
+    }
+    if initial_comment:
+        complete_payload['initial_comment'] = initial_comment
+
+    resp = requests.post('https://slack.com/api/files.completeUploadExternal',
+                         json=complete_payload, headers={
+                             **headers,
+                             'Content-Type': 'application/json',
+                         })
+    resp.raise_for_status()
+    data = resp.json()
+
+    if not data.get('ok'):
+        raise SlackAPIError('files.completeUploadExternal', data.get('error', 'unknown'))
+
+    return data

--- a/src/randomtools/slack/messages.py
+++ b/src/randomtools/slack/messages.py
@@ -1,0 +1,37 @@
+"""Slack message sending via chat.postMessage."""
+
+from __future__ import annotations
+
+import requests
+
+from .channels import SlackAPIError
+
+
+def post_message(token: str, channel_id: str, text: str) -> dict:
+    """Send a text message to a Slack channel via ``chat.postMessage``.
+
+    Args:
+        token (str): Slack API token.
+        channel_id (str): Channel ID to post to.
+        text (str): Message text (supports Slack mrkdwn formatting).
+
+    Returns:
+        dict: Slack API response data.
+
+    Raises:
+        SlackAPIError: If the Slack API returns an error.
+    """
+    resp = requests.post('https://slack.com/api/chat.postMessage', json={
+        'channel': channel_id,
+        'text': text,
+    }, headers={
+        'Authorization': f'Bearer {token}',
+        'Content-Type': 'application/json',
+    })
+    resp.raise_for_status()
+    data = resp.json()
+
+    if not data.get('ok'):
+        raise SlackAPIError('chat.postMessage', data.get('error', 'unknown'))
+
+    return data

--- a/src/randomtools/slack/send.py
+++ b/src/randomtools/slack/send.py
@@ -1,0 +1,95 @@
+"""Send a message or file to a Slack channel.
+
+Usage:
+    slack-send [options] CHANNEL [TEXT...]
+    slack-send [options] CHANNEL -f FILE [TEXT...]
+
+Options:
+    -f FILE, --file FILE           Send FILE as a Slack file upload.
+    -h, --help                     Show this message.
+    --version                      Show version information.
+
+Arguments:
+    CHANNEL   Channel name or ID (e.g. general, #general, C01234ABCDE).
+    TEXT      Message text. If omitted and no --file, reads from stdin.
+              When used with --file, sent as the accompanying comment.
+
+Examples:
+    slack-send general "Hello, world!"
+    slack-send '#dev' "Deploy complete"
+    echo "Pipeline passed" | slack-send general
+    slack-send general -f report.md
+    slack-send general -f report.md "Weekly report"
+    echo "See attached" | slack-send general -f report.md
+"""
+
+import sys
+from pathlib import Path
+
+from docopt import docopt
+
+from ..config.slack import SlackConfigFile
+from .channels import SlackAPIError, find_channel
+from .files import upload_file
+from .messages import post_message
+
+VERSION = '1.0'
+
+
+def main():
+    """Main entry point for slack-send command."""
+    arguments = docopt(__doc__, version=VERSION)
+
+    channel = arguments['CHANNEL']
+    text_parts = arguments['TEXT']
+    file_path = arguments['--file']
+
+    # Resolve text from args or stdin
+    if text_parts:
+        text = ' '.join(text_parts)
+    elif not sys.stdin.isatty():
+        text = sys.stdin.read().strip() or None
+    else:
+        text = None
+
+    if not file_path and not text:
+        print("No text provided.", file=sys.stderr)
+        return 1
+
+    try:
+        config = SlackConfigFile()
+    except KeyError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+
+    try:
+        channel_id, _ = find_channel(config.token, channel)
+    except SlackAPIError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+
+    try:
+        if file_path:
+            p = Path(file_path)
+            if not p.exists():
+                print(f"File not found: {file_path}", file=sys.stderr)
+                return 1
+            upload_file(
+                config.token, channel_id,
+                p.name, p.read_bytes(),
+                initial_comment=text,
+                title=p.stem,
+            )
+            print(f"Uploaded {p.name} to #{channel}", file=sys.stderr)
+        if text and not file_path:
+            post_message(config.token, channel_id, text)
+            print(f"Message sent to #{channel}", file=sys.stderr)
+    except SlackAPIError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/src/randomtools/slack_channels.py
+++ b/src/randomtools/slack_channels.py
@@ -22,70 +22,11 @@ import sys
 import datetime
 
 from docopt import docopt
-import requests
 
 from .config.slack import SlackConfigFile
+from .slack import fetch_all_channels, fetch_last_message_ts
 
 VERSION = '1.1'
-
-
-def fetch_channels(token):
-    """Fetch all public channels using Slack conversations.list API with pagination.
-
-    Requires a user token (xoxp-...) to see all channels the user has access to.
-    """
-    channels = []
-    cursor = None
-    url = 'https://slack.com/api/conversations.list'
-
-    while True:
-        params = {
-            'types': 'public_channel,private_channel',
-            'exclude_archived': 'true',
-            'limit': 1000,
-        }
-
-        if cursor:
-            params['cursor'] = cursor
-
-        resp = requests.post(url, data=params, headers={
-            'Authorization': f'Bearer {token}',
-        })
-        resp.raise_for_status()
-        data = resp.json()
-
-        if not data.get('ok'):
-            print(f"Slack API error: {data.get('error', 'unknown')}", file=sys.stderr)
-            sys.exit(1)
-
-        channels.extend(data.get('channels', []))
-
-        cursor = data.get('response_metadata', {}).get('next_cursor')
-        if not cursor:
-            break
-
-    return channels
-
-
-def fetch_last_message_ts(token, channel_id):
-    """Fetch the timestamp of the last message in a channel."""
-    resp = requests.post('https://slack.com/api/conversations.history', data={
-        'channel': channel_id,
-        'limit': 1,
-    }, headers={
-        'Authorization': f'Bearer {token}',
-    })
-    resp.raise_for_status()
-    data = resp.json()
-
-    if not data.get('ok'):
-        return None
-
-    messages = data.get('messages', [])
-    if not messages:
-        return None
-
-    return float(messages[0]['ts'])
 
 
 def match_channels(channels, patterns):
@@ -155,7 +96,7 @@ def main():
             print(f"--days must be an integer, got: {days_filter}", file=sys.stderr)
             sys.exit(1)
 
-    channels = fetch_channels(config.token)
+    channels = fetch_all_channels(config.token)
     matched = match_channels(channels, patterns)
 
     if not matched:


### PR DESCRIPTION
## Summary
- Extract duplicated Slack API functions from `jira_calendar.py`, `jira_report_weekly.py`, and `slack_channels.py` into a shared `randomtools.slack` package (`channels`, `messages`, `files` modules)
- Add `slack-send` CLI tool for sending text messages or file uploads to Slack channels
- Add API docs in `docs/slack.md` with type hints and docstrings

## Test plan
- [x] `pip install -e .` installs without errors
- [x] `slack-send --help` prints usage
- [x] `slack-send general "test"` sends a message
- [x] `echo "test" | slack-send general` sends via stdin
- [x] `slack-send general -f file.md "comment"` uploads file with comment
- [x] `jira-report-weekly`, `jira-calendar`, `slack-channels` still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)