### PR TITLE
feat: add --days option to jira-report

### DIFF
--- a/src/randomtools/jira_report.py
+++ b/src/randomtools/jira_report.py
@@ -8,6 +8,7 @@ Options:
     --version               Show version information.
     --month                 Report for the current calendar month.
     --week                  Report for the current calendar week.
+    --days N                Report for the last N days (including today).
     -d, --from-date DATE    Start date (YYYY-MM-DD or relative).
     -D, --to-date DATE      End date (YYYY-MM-DD or relative).
     -Y, --last              Previous period (--month/--week) or yesterday.
@@ -80,6 +81,11 @@ def resolve_period(arguments):
             monday = monday - datetime.timedelta(weeks=1)
         sunday = monday + datetime.timedelta(days=6)
         return monday, sunday
+
+    if arguments['--days']:
+        n = int(arguments['--days'])
+        start_date = today - datetime.timedelta(days=n - 1)
+        return start_date, today
 
     from_date = arguments['--from-date']
     to_date = arguments['--to-date']


### PR DESCRIPTION
## Summary
- Adds `--days N` option to `jira-report` that reports worklogs for the last N days (including today)

## Test plan
- [x] Run `jira-report --days 7` and confirm it reports the last 7 days
- [x] Run `jira-report --days 1` and confirm it reports today only

🤖 Generated with [Claude Code](https://claude.com/claude-code)